### PR TITLE
Fix/retrofit token service

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+indent_style=tab
+indent_size=4

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ target
 .settings
 .classpath
 .project
+
+#Intellij files
+.idea
+*.iml

--- a/oauth2-api/pom.xml
+++ b/oauth2-api/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>
 

--- a/oauth2-api/src/main/java/net/oauth2/AccessToken.java
+++ b/oauth2-api/src/main/java/net/oauth2/AccessToken.java
@@ -1,13 +1,14 @@
-/* 
+/*
  * Copyright (c) 2017 Georgi Pavlov (georgi.pavlov@isoft-technology.com).
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the MIT license which accompanies 
- * this distribution, and is available at 
+ * are made available under the terms of the MIT license which accompanies
+ * this distribution, and is available at
  * https://github.com/tengia/oauth-2/blob/master/LICENSE
  */
 
 package net.oauth2;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -18,7 +19,7 @@ import java.util.Map;
  * https://tools.ietf.org/html/rfc6749#section-4.1.4
  */
 public class AccessToken implements ParametersMap {
-	
+
 	/**
 	 * The access token string as issued by the authorization server.
 	 * Required.
@@ -28,20 +29,20 @@ public class AccessToken implements ParametersMap {
 	 * The type of this token, typically just the string “bearer”.
 	 * Required
 	 */
-	private String tokenType;	
+	private String tokenType;
 	/**
 	 * If the access token expires, the server should reply with the duration of time the access token is granted for.
 	 * Required
 	 */
 	private long expiresIn;
 	/**
-	 * If the access token will expire, then it is useful to return a refresh token which applications can use to obtain another access token. 
+	 * If the access token will expire, then it is useful to return a refresh token which applications can use to obtain another access token.
 	 * However, tokens issued with the implicit grant cannot be issued a refresh token.
 	 * Optional
 	 */
 	private String refreshToken;
 	/**
-	 *  If the scope the user granted is identical to the scope the app requested, this parameter is optional. 
+	 *  If the scope the user granted is identical to the scope the app requested, this parameter is optional.
 	 *  If the granted scope is different from the requested scope, such as if the user modified the scope, then this parameter is required.
 	 *  Optional
 	 */
@@ -49,26 +50,26 @@ public class AccessToken implements ParametersMap {
 
 	/**
 	 * Initializes an oauth token object from standard properties.
-	 * 
+	 *
 	 * @param accessToken the "access_token" string.
 	 * @param tokenType the "token_type" string. Defaults to "Bearer".
 	 * @param expiresIn the "expires_in" integer number for seconds until expire.
 	 * @param refreshToken the "refresh_token" string.
-	 * @param scopes the token "scope" as a collection of scope strings 
+	 * @param scopes the token "scope" as a collection of scope strings
 	 */
 	public AccessToken(final String accessToken, String tokenType, final long expiresIn, final String refreshToken, final Collection<String> scopes) {
 		this.accessToken = accessToken;
 		if (tokenType == null)
 			tokenType = "Bearer";
 		this.tokenType = tokenType;
-		this.expiresIn = expiresIn;		
+		this.expiresIn = expiresIn;
 		this.refreshToken = refreshToken;
 		this.scopes = scopes;
 	}
-	
+
 	/**
 	 * Initialize from map of properties such as "access_token" and "expires_in".
-	 * 
+	 *
 	 * @param map
 	 */
 	@SuppressWarnings("unchecked")
@@ -77,11 +78,18 @@ public class AccessToken implements ParametersMap {
 			throw new IllegalArgumentException("map is null");
 		this.accessToken = (String) map.get("access_token");
 		this.tokenType = (String) map.getOrDefault("token_type", "Bearer");
-		Long val = (Long) map.get("expires_in");
-		if(val!=null)
-			this.expiresIn = Long.parseLong(String.valueOf(val));
+		if(map.containsKey("expires_in")){
+			//Create a new long so that the case where expires_in is an integer is handled.
+			this.expiresIn = new Long(String.valueOf(map.get("expires_in")));
+		}
 		this.refreshToken = (String) map.get("refresh_token");
-		this.scopes = (Collection<String>) map.get("scope");
+		if(map.containsKey("scope")){
+            if(map.get("scope") instanceof Collection<?>){
+                this.scopes = (Collection<String>) map.get("scope");
+            } else{
+                this.scopes = Arrays.asList(((String) map.get("scope")).split(""));
+            }
+        }
 	}
 
 	/**
@@ -119,7 +127,7 @@ public class AccessToken implements ParametersMap {
 	public final long getExpiresIn() {
 		return expiresIn;
 	}
-	
+
 	/**
 	 * Checks if scope is one of the configured scopes for this access token.
 	 * @param scope
@@ -134,13 +142,13 @@ public class AccessToken implements ParametersMap {
 		return "AccessToken [accessToken=" + accessToken + ", tokenType=" + tokenType + ", expiresIn=" + expiresIn
 				+ ", refreshToken=" + refreshToken + ", scopes=" + scopes + "]";
 	}
-	
+
 	private static Map<String, String> propertyMap;
 
 	/**
 	 * Maps Bean introspection property descriptors name to OAuth2 valid payload
 	 * property names.
-	 * 
+	 *
 	 * @return
 	 */
 	protected static Map<String, String> getPropertyMap() {
@@ -158,7 +166,7 @@ public class AccessToken implements ParametersMap {
 
 	/**
 	 * Returns the properties of this token object as map.
-	 * 
+	 *
 	 */
 	public Map<String, Object> map() throws Exception {
 		Map<String, Object> grant = BeanUtils.asMap(this, getPropertyMap());

--- a/oauth2-api/src/main/java/net/oauth2/AccessToken.java
+++ b/oauth2-api/src/main/java/net/oauth2/AccessToken.java
@@ -87,7 +87,7 @@ public class AccessToken implements ParametersMap {
             if(map.get("scope") instanceof Collection<?>){
                 this.scopes = (Collection<String>) map.get("scope");
             } else{
-                this.scopes = Arrays.asList(((String) map.get("scope")).split(""));
+                this.scopes = Arrays.asList(((String) map.get("scope")).split(" "));
             }
         }
 	}

--- a/oauth2-api/src/main/java/net/oauth2/AccessTokenGrantRequest.java
+++ b/oauth2-api/src/main/java/net/oauth2/AccessTokenGrantRequest.java
@@ -1,8 +1,8 @@
-/* 
+/*
  * Copyright (c) 2017 Georgi Pavlov (georgi.pavlov@isoft-technology.com).
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the MIT license which accompanies 
- * this distribution, and is available at 
+ * are made available under the terms of the MIT license which accompanies
+ * this distribution, and is available at
  * https://github.com/tengia/oauth-2/blob/master/LICENSE
  */
 
@@ -26,7 +26,7 @@ public class AccessTokenGrantRequest implements ParametersMap{
 
 	/**
 	 * Initializes grant request from properties.
-	 * 
+	 *
 	 * @param grantType The grant type of this grant request, such as "authorization_code" or "client_secret"
 	 * @param clientId The client id in this grant request
 	 * @param clientSecret The client secret in this grant request
@@ -69,7 +69,7 @@ public class AccessTokenGrantRequest implements ParametersMap{
 	/**
 	 * Maps Bean introspection property descriptors name to OAuth2 valid payload
 	 * property names.
-	 * 
+	 *
 	 * @return
 	 */
 	protected static Map<String, String> getPropertyMap() {
@@ -78,7 +78,6 @@ public class AccessTokenGrantRequest implements ParametersMap{
 			propertyMap.put("grantType", "grant_type");
 			propertyMap.put("clientId", "client_id");
 			propertyMap.put("clientSecret", "client_secret");
-			propertyMap.put("scopes", "scope");
 			propertyMap = Collections.unmodifiableMap(propertyMap);
 		}
 		return propertyMap;
@@ -87,6 +86,9 @@ public class AccessTokenGrantRequest implements ParametersMap{
 	@Override
 	public Map<String, Object> map() throws Exception {
 		Map<String, Object> grant = BeanUtils.asMap(this, getPropertyMap());
+		if(this.scope !=null){
+			grant.put("scope",String.join(" ", this.scope));
+		}
 		return grant;
 	}
 
@@ -132,11 +134,8 @@ public class AccessTokenGrantRequest implements ParametersMap{
 		} else if (!grant_type.equals(other.grant_type))
 			return false;
 		if (scope == null) {
-			if (other.scope != null)
-				return false;
-		} else if (!scope.equals(other.scope))
-			return false;
-		return true;
-	}
+            return other.scope == null;
+		} else return scope.equals(other.scope);
+    }
 
 }

--- a/oauth2-api/src/main/java/net/oauth2/client/http/FormEncodeDataBinding.java
+++ b/oauth2-api/src/main/java/net/oauth2/client/http/FormEncodeDataBinding.java
@@ -66,13 +66,13 @@ public class FormEncodeDataBinding extends WwwFormUrlEncodedCodec {
 	 * @return
 	 */
 	public <T extends ParametersMap> String encode(final T bag, @SuppressWarnings("rawtypes") Map<String, Serializer> serializersMappings) {
-		Map<String, Object> grantRequestFormFrields = null;
+		Map<String, Object> grantRequestFormFields = null;
 		try {
-			grantRequestFormFrields = bag.map();
+			grantRequestFormFields = bag.map();
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
-		return this.encodeStream(grantRequestFormFrields.entrySet().stream(), serializersMappings);
+		return this.encodeStream(grantRequestFormFields.entrySet().stream(), serializersMappings);
 	}
 	
 	// Decoding

--- a/oauth2-api/src/test/java/net/oauth2/AccessTokenTest.java
+++ b/oauth2-api/src/test/java/net/oauth2/AccessTokenTest.java
@@ -93,7 +93,7 @@ public class AccessTokenTest {
     @Test
     public void testMapConstructorSpaceSeparatedScopesString() {
         Map<String, Object> map = new HashMap<>();
-        Collection<String> scopes = new ArrayList<>();d
+        Collection<String> scopes = new ArrayList<>();
         scopes.add("a");
         scopes.add("b");
         map.put("scope", "a b");

--- a/oauth2-api/src/test/java/net/oauth2/AccessTokenTest.java
+++ b/oauth2-api/src/test/java/net/oauth2/AccessTokenTest.java
@@ -1,19 +1,17 @@
-/* 
+/*
  * Copyright (c) 2017 Georgi Pavlov (georgi.pavlov@isoft-technology.com).
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the MIT license which accompanies 
- * this distribution, and is available at 
+ * are made available under the terms of the MIT license which accompanies
+ * this distribution, and is available at
  * https://github.com/tengia/oauth-2/blob/master/LICENSE
  */
 
 package net.oauth2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -21,74 +19,116 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 @RunWith(MockitoJUnitRunner.class)
 public class AccessTokenTest {
 
-	Collection<String> scopes = new ArrayList<>(3);	
-	
-	@Before
-	public void before() {
-		scopes.add("a");
-		scopes.add("b");
-		scopes.add("c");		
-	}
-	
-	@Test
-	public void testHasScope() {
-		AccessToken token = new AccessToken(null, null, 0, null, scopes);
-		boolean hasScope = token.hasScope("a");
-		assertTrue(hasScope);
-	}
-	@Test
-	public void testHasScopeNegative() {
-		AccessToken token = new AccessToken(null, null, 0, null, scopes);
-		boolean hasScope = token.hasScope("d");
-		assertFalse(hasScope);
-	}
-	
-	@Test
-	public void testHasScopeNull() {
-		AccessToken token = new AccessToken(null, null, 0, null, null);
-		boolean hasScope = token.hasScope("a");
-		assertFalse(hasScope);
-	}
-	
-	@Test
-	public void testHasScopeNullAndNegative() {
-		AccessToken token = new AccessToken(null, null, 0, null, null);
-		boolean hasScope = token.hasScope("d");
-		assertFalse(hasScope);
-	}
-		
-	@Test
-	public void testGetters() {
-		String tokenType = "OAuth";
-		String tokenString = "token";
-		long expiresIn = 3600;
-		String refreshToken = "refresh-token";
-		AccessToken token = new AccessToken(tokenString, tokenType, expiresIn, refreshToken, scopes);
-		assertEquals(tokenType, token.getTokenType());
-		assertEquals(tokenString, token.getAccessToken());
-		assertEquals(expiresIn, token.getExpiresIn());
-		assertEquals(refreshToken, token.getRefreshToken());
-		assertEquals(this.scopes, token.getScopes());
-	}
-	
-	
-	@Test
-	public void testToString() {
-		String tokenType = "OAuth";
-		String tokenString = "token";
-		long expiresIn = 3600;
-		String refreshToken = "refresh-token";
-		AccessToken token = new AccessToken(tokenString, tokenType, expiresIn, refreshToken, scopes);
-		String s = token.toString();
-		assertEquals("AccessToken [accessToken=token, tokenType=OAuth, expiresIn=3600, refreshToken=refresh-token, scopes=[a, b, c]]", s);
-	}
-		
-	@After
-	public void after() {
-		scopes.clear();
-	}
+    private Collection<String> scopes = new ArrayList<>(3);
+
+    @Before
+    public void before() {
+        scopes.add("a");
+        scopes.add("b");
+        scopes.add("c");
+    }
+
+    @Test
+    public void testHasScope() {
+        AccessToken token = new AccessToken(null, null, 0, null, scopes);
+        boolean hasScope = token.hasScope("a");
+        assertTrue(hasScope);
+    }
+
+    @Test
+    public void testHasScopeNegative() {
+        AccessToken token = new AccessToken(null, null, 0, null, scopes);
+        boolean hasScope = token.hasScope("d");
+        assertFalse(hasScope);
+    }
+
+    @Test
+    public void testHasScopeNull() {
+        AccessToken token = new AccessToken(null, null, 0, null, null);
+        boolean hasScope = token.hasScope("a");
+        assertFalse(hasScope);
+    }
+
+    @Test
+    public void testHasScopeNullAndNegative() {
+        AccessToken token = new AccessToken(null, null, 0, null, null);
+        boolean hasScope = token.hasScope("d");
+        assertFalse(hasScope);
+    }
+
+    @Test
+    public void testMapConstructorLongExpiresIn() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("expires_in", 1L);
+        AccessToken token = new AccessToken(map);
+        assertEquals(1L, token.getExpiresIn());
+    }
+
+    @Test
+    public void testMapConstructorIntegerExpiresIn() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("expires_in", 1);
+        AccessToken token = new AccessToken(map);
+        assertEquals(1L, token.getExpiresIn());
+    }
+
+    @Test
+    public void testMapConstructorScopeCollection() {
+        Map<String, Object> map = new HashMap<>();
+        Collection<String> scopes = new ArrayList<>();
+        scopes.add("a");
+        scopes.add("b");
+        map.put("scope", scopes);
+        AccessToken token = new AccessToken(map);
+        assertEquals(scopes, token.getScopes());
+    }
+
+    @Test
+    public void testMapConstructorSpaceSeparatedScopesString() {
+        Map<String, Object> map = new HashMap<>();
+        Collection<String> scopes = new ArrayList<>();d
+        scopes.add("a");
+        scopes.add("b");
+        map.put("scope", "a b");
+        AccessToken token = new AccessToken(map);
+        assertEquals(scopes, token.getScopes());
+    }
+
+    @Test
+    public void testGetters() {
+        String tokenType = "OAuth";
+        String tokenString = "token";
+        long expiresIn = 3600;
+        String refreshToken = "refresh-token";
+        AccessToken token = new AccessToken(tokenString, tokenType, expiresIn, refreshToken, scopes);
+        assertEquals(tokenType, token.getTokenType());
+        assertEquals(tokenString, token.getAccessToken());
+        assertEquals(expiresIn, token.getExpiresIn());
+        assertEquals(refreshToken, token.getRefreshToken());
+        assertEquals(this.scopes, token.getScopes());
+    }
+
+    @Test
+    public void testToString() {
+        String tokenType = "OAuth";
+        String tokenString = "token";
+        long expiresIn = 3600;
+        String refreshToken = "refresh-token";
+        AccessToken token = new AccessToken(tokenString, tokenType, expiresIn, refreshToken, scopes);
+        String s = token.toString();
+        assertEquals("AccessToken [accessToken=token, tokenType=OAuth, expiresIn=3600, refreshToken=refresh-token, scopes=[a, b, c]]", s);
+    }
+
+    @After
+    public void after() {
+        scopes.clear();
+    }
 
 }

--- a/oauth2-api/src/test/java/net/oauth2/client/AccessTokenGrantTests.java
+++ b/oauth2-api/src/test/java/net/oauth2/client/AccessTokenGrantTests.java
@@ -1,214 +1,220 @@
-/* 
+/*
  * Copyright (c) 2017 Georgi Pavlov (georgi.pavlov@isoft-technology.com).
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the MIT license which accompanies 
- * this distribution, and is available at 
+ * are made available under the terms of the MIT license which accompanies
+ * this distribution, and is available at
  * https://github.com/tengia/oauth-2/blob/master/LICENSE
  */
 
 package net.oauth2.client;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
-
 import net.oauth2.AccessTokenGrantRequest;
 import net.oauth2.AuthorizationCodeGrantRequest;
 import net.oauth2.ClientCredentialsGrantRequest;
 import net.oauth2.PasswordCredentialsGrantRequest;
 import net.oauth2.RefreshTokenGrantRequest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class AccessTokenGrantTests {
 
-	@Test
-	public void testAccessTokenGrantRequest() {
-		String grantType = "grant-type";
-		String clientId = "client-id";
-		String clientSecret = "client-secret";
-		Collection<String> scopes = new ArrayList<>();
-		scopes.add("scope");
-		AccessTokenGrantRequest req = new AccessTokenGrantRequest(grantType, clientId, clientSecret, scopes);
-		assertEquals(grantType, req.getGrantType());
-		assertEquals(clientId, req.getClientId());
-		assertEquals(clientSecret, req.getClientSecret());
-		assertEquals(scopes, req.getScopes());
-	}
-	
-	@Test
-	public void testRefreshTokenGrantRequest() {
-		String grantType = "refresh_token";
-		String clientId = "client-id";
-		String clientSecret = "client-secret";
-		String refreshToken = "refresh-token";
-		Collection<String> scopes = new ArrayList<>();
-		scopes.add("scope");
-		RefreshTokenGrantRequest req = new RefreshTokenGrantRequest(refreshToken, clientId, clientSecret, scopes);
-		assertEquals(grantType, req.getGrantType());
-		assertEquals(clientId, req.getClientId());
-		assertEquals(clientSecret, req.getClientSecret());
-		assertEquals(refreshToken, req.getRefreshToken());
-		assertEquals(scopes, req.getScopes());
-	}
-		
-	@Test
-	public void testClientCredentialsGrantRequest() {
-		String grantType = "client_credentials";
-		String clientId = "client-id";
-		String clientSecret = "client-secret";
-		Collection<String> scopes = new ArrayList<>();
-		scopes.add("scope");
-		ClientCredentialsGrantRequest req = new ClientCredentialsGrantRequest(clientId, clientSecret, scopes);
-		assertEquals(grantType, req.getGrantType());
-		assertEquals(clientId, req.getClientId());
-		assertEquals(clientSecret, req.getClientSecret());
-		assertEquals(scopes, req.getScopes());
-	}
-	
-	@Test
-	public void testAuthorizationCodeGrantRequest() {
-		String grantType = "authorization_code";
-		String code = "code";
-		String clientId = "client-id";
-		String clientSecret = "client-secret";
-		String redirectUrl= "";
-		Collection<String> scopes = new ArrayList<>();
-		scopes.add("scope");
-		AuthorizationCodeGrantRequest req = new AuthorizationCodeGrantRequest(code, clientId, clientSecret, redirectUrl, scopes);
-		assertEquals(grantType, req.getGrantType());
-		assertEquals(code, req.getCode());
-		assertEquals(clientId, req.getClientId());
-		assertEquals(clientSecret, req.getClientSecret());
-		assertEquals(redirectUrl, req.getRedirectUri());
-		assertEquals(scopes, req.getScopes());
-	}
-	
-	@Test
-	public void testPasswordCredentialsGrantRequest() {
-		String grantType = "password";
-		String username = "code";
-		String password= "pass";
-		String clientId = "client-id";
-		String clientSecret = "client-secret";
-		Collection<String> scopes = new ArrayList<>();
-		scopes.add("scope");
-		PasswordCredentialsGrantRequest req = new PasswordCredentialsGrantRequest(username, password, clientId, clientSecret, scopes);
-		assertEquals(grantType, req.getGrantType());
-		assertEquals(username, req.getUsername());
-		assertEquals(clientId, req.getClientId());
-		assertEquals(password, req.getPassword());
-		assertEquals(clientSecret, req.getClientSecret());
-		assertEquals(scopes, req.getScopes());
-	}
-	
-	
-	public static class TestPojo extends AccessTokenGrantRequest{
-		public TestPojo(String grantType, String clientId, String clientSecret, Collection<String> scope) {
-			super(grantType, clientId, clientSecret, scope);
-		}
-		public long getLongPrimitive(){
-			return 123L;
-		}
-		public Collection<String> getCollection(){
-			Collection<String> c = new ArrayList<>();
-			c.add("collectionvalue");
-			return c;
-		}
-		@Override
-		public Map<String, Object> map() throws Exception {
-			Map<String, Object> _m = new HashMap<>(super.map());
-			_m.put("long_prop", this.getLongPrimitive());
-			_m.put("collection_prop", this.getCollection());
-			return _m;
-		}
-	}
+    @Test
+    public void testAccessTokenGrantRequest() {
+        String grantType = "grant-type";
+        String clientId = "client-id";
+        String clientSecret = "client-secret";
+        Collection<String> scopes = new ArrayList<>();
+        scopes.add("scope");
+        AccessTokenGrantRequest req = new AccessTokenGrantRequest(grantType, clientId, clientSecret, scopes);
+        assertEquals(grantType, req.getGrantType());
+        assertEquals(clientId, req.getClientId());
+        assertEquals(clientSecret, req.getClientSecret());
+        assertEquals(scopes, req.getScopes());
+    }
 
-	@Test
-	public void testAsMap() throws Exception{
-		TestPojo tp = new TestPojo("test", "abc", "secret", null);
-		Map<String, Object> map = tp.map();
-		assertEquals("test", map.get("grant_type"));
-		assertTrue(((Long)map.get("long_prop")).longValue() == 123L);
-		assertEquals(map.get("collection_prop"), tp.getCollection());
-	}
-	
-	@Test
-	public void testToString() {
-		AccessTokenGrantRequest grantRequest = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		assertEquals("AccessTokenGrantRequest [grant_type=grant_type, client_id=client_id, client_secret=client_secret, scope=null]", grantRequest.toString());
-	}
-		
-	@Test
-	public void testEqualsIsReflexive() {
-		AccessTokenGrantRequest grantRequest = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		// must be reflexive: for any non-null reference value x, x.equals(x) must return true
-		assertTrue(grantRequest.equals(grantRequest));
-		// more than one invocation of hashCode() on the same object will return the same integer
-		assertTrue(grantRequest.hashCode() == grantRequest.hashCode());
-	}
-	
-	@Test
-	public void testEqualsIsSymmetric() {
-		AccessTokenGrantRequest grantRequest1 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		AccessTokenGrantRequest grantRequest2 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+    @Test
+    public void testRefreshTokenGrantRequest() {
+        String grantType = "refresh_token";
+        String clientId = "client-id";
+        String clientSecret = "client-secret";
+        String refreshToken = "refresh-token";
+        Collection<String> scopes = new ArrayList<>();
+        scopes.add("scope");
+        RefreshTokenGrantRequest req = new RefreshTokenGrantRequest(refreshToken, clientId, clientSecret, scopes);
+        assertEquals(grantType, req.getGrantType());
+        assertEquals(clientId, req.getClientId());
+        assertEquals(clientSecret, req.getClientSecret());
+        assertEquals(refreshToken, req.getRefreshToken());
+        assertEquals(scopes, req.getScopes());
+    }
 
-		// must be symmetric: for any non-null reference values x and y, x.equals(y) must return true if and only if y.equals(x) returns true
-		assertTrue(grantRequest1.equals(grantRequest2) && grantRequest1.equals(grantRequest2));
-		//Invocation of hashCode on equal objects produces the same integer
-		assertTrue(grantRequest1.hashCode() == grantRequest2.hashCode());
-	}
-	
-	@Test
-	public void testEqualsIsTransitive() {
-		AccessTokenGrantRequest grantRequest1 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		AccessTokenGrantRequest grantRequest2 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		AccessTokenGrantRequest grantRequest3 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		
-		// must be transitive: for any non-null reference value x, y and z, if x.equals(y) returns true and y.equals(z) returns true, then x.equals(z) must return true
-		assertTrue(grantRequest1.equals(grantRequest2) && grantRequest2.equals(grantRequest3) && grantRequest1.equals(grantRequest3));
-		// Invocation of hashCode on equal objects produces the same integer
-		assertTrue(grantRequest1.hashCode() == grantRequest2.hashCode() && grantRequest1.hashCode() == grantRequest3.hashCode());
-	}
-	
-	@Test
-	public void testEqualsIsConsistent() {
-		AccessTokenGrantRequest grantRequest1 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		AccessTokenGrantRequest grantRequest2 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		
-		// must be consistent: for any non-null reference values x and y, multiple invocations of x.equals(y) must return the same result if no information used in equals comparison test is modifed
-		assertTrue(grantRequest1.equals(grantRequest2) && grantRequest1.equals(grantRequest2));
-	}
-	
-	@Test
-	public void testEqualsIsFalseForNullArguments() {
-		AccessTokenGrantRequest grantRequest = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		//handling null arguments: for any non-null reference value x, x.equals(null) must return false
-		assertFalse(grantRequest.equals(null));
-	}
-	
-	@Test
-	public void testEqualsIsFalseForDifferentTypeArguments() {
-		AccessTokenGrantRequest grantRequest = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		//test on equality with different type will return false
-		assertFalse(grantRequest.equals(new Object()));
-	}
-	
-	@Test
-	public void testEqualsIsFalseOnNotEqualCfgObjects() {
-		
-		AccessTokenGrantRequest grantRequest1 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
-		AccessTokenGrantRequest grantRequest2 = new AccessTokenGrantRequest("grant_type1", "client_id1", "client_secret1", null);
-		
-		// objects are not equal
-		assertFalse(grantRequest1.equals(grantRequest2));
-		// Invocation of hashCode on not equal objects produces different results
-		assertTrue(grantRequest1.hashCode() != grantRequest2.hashCode());
-	}
-	
+    @Test
+    public void testClientCredentialsGrantRequest() {
+        String grantType = "client_credentials";
+        String clientId = "client-id";
+        String clientSecret = "client-secret";
+        Collection<String> scopes = new ArrayList<>();
+        scopes.add("scope");
+        ClientCredentialsGrantRequest req = new ClientCredentialsGrantRequest(clientId, clientSecret, scopes);
+        assertEquals(grantType, req.getGrantType());
+        assertEquals(clientId, req.getClientId());
+        assertEquals(clientSecret, req.getClientSecret());
+        assertEquals(scopes, req.getScopes());
+    }
+
+    @Test
+    public void testAuthorizationCodeGrantRequest() {
+        String grantType = "authorization_code";
+        String code = "code";
+        String clientId = "client-id";
+        String clientSecret = "client-secret";
+        String redirectUrl = "";
+        Collection<String> scopes = new ArrayList<>();
+        scopes.add("scope");
+        AuthorizationCodeGrantRequest req = new AuthorizationCodeGrantRequest(code, clientId, clientSecret, redirectUrl, scopes);
+        assertEquals(grantType, req.getGrantType());
+        assertEquals(code, req.getCode());
+        assertEquals(clientId, req.getClientId());
+        assertEquals(clientSecret, req.getClientSecret());
+        assertEquals(redirectUrl, req.getRedirectUri());
+        assertEquals(scopes, req.getScopes());
+    }
+
+    @Test
+    public void testPasswordCredentialsGrantRequest() {
+        String grantType = "password";
+        String username = "code";
+        String password = "pass";
+        String clientId = "client-id";
+        String clientSecret = "client-secret";
+        Collection<String> scopes = new ArrayList<>();
+        scopes.add("scope");
+        PasswordCredentialsGrantRequest req = new PasswordCredentialsGrantRequest(username, password, clientId, clientSecret, scopes);
+        assertEquals(grantType, req.getGrantType());
+        assertEquals(username, req.getUsername());
+        assertEquals(clientId, req.getClientId());
+        assertEquals(password, req.getPassword());
+        assertEquals(clientSecret, req.getClientSecret());
+        assertEquals(scopes, req.getScopes());
+    }
+
+    @Test
+    public void testAsMap() throws Exception {
+        Collection<String> scope = new ArrayList<>();
+        scope.add("a");
+        scope.add("b");
+        TestPojo tp = new TestPojo("test", "abc", "secret", scope);
+        Map<String, Object> map = tp.map();
+        assertEquals("test", map.get("grant_type"));
+        assertEquals(123L, ((Long) map.get("long_prop")).longValue());
+        assertEquals(map.get("collection_prop"), tp.getCollection());
+        assertEquals("a b", map.get("scope"));
+    }
+
+    @Test
+    public void testToString() {
+        AccessTokenGrantRequest grantRequest = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+        assertEquals("AccessTokenGrantRequest [grant_type=grant_type, client_id=client_id, client_secret=client_secret, scope=null]", grantRequest.toString());
+    }
+
+    @Test
+    public void testEqualsIsReflexive() {
+        AccessTokenGrantRequest grantRequest = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+        // must be reflexive: for any non-null reference value x, x.equals(x) must return true
+        assertEquals(grantRequest, grantRequest);
+        // more than one invocation of hashCode() on the same object will return the same integer
+        assertEquals(grantRequest.hashCode(), grantRequest.hashCode());
+    }
+
+    @Test
+    public void testEqualsIsSymmetric() {
+        AccessTokenGrantRequest grantRequest1 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+        AccessTokenGrantRequest grantRequest2 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+
+        // must be symmetric: for any non-null reference values x and y, x.equals(y) must return true if and only if y.equals(x) returns true
+        assertTrue(grantRequest1.equals(grantRequest2) && grantRequest1.equals(grantRequest2));
+        //Invocation of hashCode on equal objects produces the same integer
+        assertEquals(grantRequest1.hashCode(), grantRequest2.hashCode());
+    }
+
+    @Test
+    public void testEqualsIsTransitive() {
+        AccessTokenGrantRequest grantRequest1 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+        AccessTokenGrantRequest grantRequest2 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+        AccessTokenGrantRequest grantRequest3 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+
+        // must be transitive: for any non-null reference value x, y and z, if x.equals(y) returns true and y.equals(z) returns true, then x.equals(z) must return true
+        assertTrue(grantRequest1.equals(grantRequest2) && grantRequest2.equals(grantRequest3) && grantRequest1.equals(grantRequest3));
+        // Invocation of hashCode on equal objects produces the same integer
+        assertTrue(grantRequest1.hashCode() == grantRequest2.hashCode() && grantRequest1.hashCode() == grantRequest3.hashCode());
+    }
+
+    @Test
+    public void testEqualsIsConsistent() {
+        AccessTokenGrantRequest grantRequest1 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+        AccessTokenGrantRequest grantRequest2 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+
+        // must be consistent: for any non-null reference values x and y, multiple invocations of x.equals(y) must return the same result if no information used in equals
+        // comparison test is modifed
+        assertTrue(grantRequest1.equals(grantRequest2) && grantRequest1.equals(grantRequest2));
+    }
+
+    @Test
+    public void testEqualsIsFalseForNullArguments() {
+        AccessTokenGrantRequest grantRequest = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+        //handling null arguments: for any non-null reference value x, x.equals(null) must return false
+        assertNotEquals(null, grantRequest);
+    }
+
+    @Test
+    public void testEqualsIsFalseForDifferentTypeArguments() {
+        AccessTokenGrantRequest grantRequest = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+        //test on equality with different type will return false
+        assertNotEquals(grantRequest, new Object());
+    }
+
+    @Test
+    public void testEqualsIsFalseOnNotEqualCfgObjects() {
+
+        AccessTokenGrantRequest grantRequest1 = new AccessTokenGrantRequest("grant_type", "client_id", "client_secret", null);
+        AccessTokenGrantRequest grantRequest2 = new AccessTokenGrantRequest("grant_type1", "client_id1", "client_secret1", null);
+
+        // objects are not equal
+        assertNotEquals(grantRequest1, grantRequest2);
+        // Invocation of hashCode on not equal objects produces different results
+        assertTrue(grantRequest1.hashCode() != grantRequest2.hashCode());
+    }
+
+    public static class TestPojo extends AccessTokenGrantRequest {
+        TestPojo(String grantType, String clientId, String clientSecret, Collection<String> scope) {
+            super(grantType, clientId, clientSecret, scope);
+        }
+
+        @Override
+        public Map<String, Object> map() throws Exception {
+            Map<String, Object> _m = new HashMap<>(super.map());
+            _m.put("long_prop", this.getLongPrimitive());
+            _m.put("collection_prop", this.getCollection());
+            return _m;
+        }
+
+        long getLongPrimitive() {
+            return 123L;
+        }
+
+        Collection<String> getCollection() {
+            Collection<String> c = new ArrayList<>();
+            c.add("collectionvalue");
+            return c;
+        }
+    }
+
 }

--- a/oauth2-client-bom/pom.xml
+++ b/oauth2-client-bom/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.oauth-2</groupId>
 	<artifactId>oauth2-client-bom</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<packaging>pom</packaging>
 	<name>OAuth2 Client BOM</name>
 	<description>OAuth2 Client Dependencies (Bill-Of-Materials)</description>
@@ -94,7 +94,7 @@
 		<url>https://github.com/tengia/oauth-2</url>
 		<connection>scm:git:git@github.com:tengia/oauth-2.git</connection>
 		<developerConnection>scm:git:git@github.com:tengia/oauth-2.git</developerConnection>
-		<tag>v1.1.0</tag>
+		<tag>v1.1.1</tag>
 	</scm>
 
 	<distributionManagement>

--- a/oauth2-client-http-apache/pom.xml
+++ b/oauth2-client-http-apache/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>
 

--- a/oauth2-client-http-javase/pom.xml
+++ b/oauth2-client-http-javase/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>
 

--- a/oauth2-client-http-okhttp3/pom.xml
+++ b/oauth2-client-http-okhttp3/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>
 

--- a/oauth2-client-retrofit2/pom.xml
+++ b/oauth2-client-retrofit2/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>
 	

--- a/oauth2-client-retrofit2/src/main/java/net/oauth2/client/retrofit/RetrofitTokenService.java
+++ b/oauth2-client-retrofit2/src/main/java/net/oauth2/client/retrofit/RetrofitTokenService.java
@@ -111,7 +111,7 @@ public class RetrofitTokenService<S extends TokenEndpoint, T extends AccessToken
 				.addInterceptor(chain -> {
 					Request request = chain.request();
 					String auth = request.header("Authorization");
-					if (auth == null && !userId.equals("") && ! password.equals("")) {
+					if (auth == null && !userId.equals("") && !password.equals("")) {
 						request = request.newBuilder()
 						.addHeader("Authorization", Credentials.basic(userId, password)).build();
 					}

--- a/oauth2-client-retrofit2/src/main/java/net/oauth2/client/retrofit/RetrofitTokenService.java
+++ b/oauth2-client-retrofit2/src/main/java/net/oauth2/client/retrofit/RetrofitTokenService.java
@@ -21,11 +21,9 @@ import net.oauth2.AccessToken;
 import net.oauth2.AccessTokenGrantRequest;
 import net.oauth2.ProtocolError;
 import net.oauth2.RefreshTokenGrantRequest;
-import net.oauth2.client.OAuth2ProtocolException;
 import net.oauth2.client.TokenService;
 import net.oauth2.jackson.OAuth2ObjectMapper;
 import okhttp3.Credentials;
-import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import retrofit2.Response;
@@ -109,34 +107,31 @@ public class RetrofitTokenService<S extends TokenEndpoint, T extends AccessToken
 	}
 	
 	protected OkHttpClient httpClient(String userId, String password){
-		OkHttpClient httpClient = new OkHttpClient.Builder()
-				.addInterceptor(new Interceptor(){
-					@Override
-					public okhttp3.Response intercept(Chain chain) throws IOException {
-						Request request = chain.request();
-						String auth = request.header("Authorization");
-						if (auth == null) {
-							request = request.newBuilder()
-							.addHeader("Authorization", Credentials.basic(userId, password)).build();
-						}
-						return chain.proceed(request);
-					}})
+		return new OkHttpClient.Builder()
+				.addInterceptor(chain -> {
+					Request request = chain.request();
+					String auth = request.header("Authorization");
+					if (auth == null && !userId.equals("") && ! password.equals("")) {
+						request = request.newBuilder()
+						.addHeader("Authorization", Credentials.basic(userId, password)).build();
+					}
+					return chain.proceed(request);
+				})
 				.build();
-		return httpClient;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public T fetch() throws OAuth2ProtocolException, IOException {
+	public T fetch() throws IOException {
 		LOGGER.trace("Fetching Access Token");
 
-		Map<String, Object> grantRequestFormFrields = null;
+		Map<String, Object> grantRequestFormFields;
 		try {
-			grantRequestFormFrields = this.grant.map();
+			grantRequestFormFields = this.grant.map();
 		} catch (Exception e) {
 			throw new IOException(e);
 		}
-		Response<String> response = this.tokenService.getAccessToken(TokenEndpoint.DEFAULT_URL_PATH, grantRequestFormFrields).execute();
+		Response<String> response = this.tokenService.getAccessToken(TokenEndpoint.DEFAULT_URL_PATH, grantRequestFormFields).execute();
 		
 		T token = null;
 		if (response.isSuccessful()) {
@@ -160,7 +155,7 @@ public class RetrofitTokenService<S extends TokenEndpoint, T extends AccessToken
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public T refresh(String refreshToken) throws OAuth2ProtocolException, IOException {
+	public T refresh(String refreshToken) throws IOException {
 		if (refreshToken == null)
 			throw new IllegalArgumentException("refreshToken is null");
 		
@@ -168,14 +163,14 @@ public class RetrofitTokenService<S extends TokenEndpoint, T extends AccessToken
 			throw new IllegalStateException("No refresh token grant initialized. Either authroization server does not support refreshing tokens or fetchToken was never invoked on this instance prior ot invoking refresh.");
 
 		LOGGER.trace("Refreshing Access Token");
-		Map<String, Object> grantRequestFormFrields = null;
+		Map<String, Object> grantRequestFormFields;
 		try {
-			grantRequestFormFrields = this.refreshTokenGrantRequest.map();
+			grantRequestFormFields = this.refreshTokenGrantRequest.map();
 		} catch (Exception e) {
 			throw new IOException(e);
 		}
 
-		Response<String> response = this.tokenService.refreshToken(TokenEndpoint.DEFAULT_URL_PATH, grantRequestFormFrields).execute();
+		Response<String> response = this.tokenService.refreshToken(TokenEndpoint.DEFAULT_URL_PATH, grantRequestFormFields).execute();
 
 		T token = null;
 		if (response.isSuccessful()) {
@@ -183,10 +178,7 @@ public class RetrofitTokenService<S extends TokenEndpoint, T extends AccessToken
 			token = (T) this.objectMapper.readValue(tokenString, this.accessTokenClass);
 			
 			Collection<String> scopes = token.getScopes();
-			String refreshTokenString = token.getRefreshToken();//did we get a new refresh string?
-			if(refreshTokenString == null)
-				refreshTokenString = refreshToken;
-			else{
+			if(token.getRefreshToken() != null){
 				 /*If a new refresh token is issued, the refresh token scope MUST be identical to that of the refresh token included by the client in the request.*/
 				if(this.refreshTokenGrantRequest.getScopes()!=scopes && (this.refreshTokenGrantRequest.getScopes().size()!= scopes.size() || !this.refreshTokenGrantRequest.getScopes().containsAll(scopes)))
 					throw new IllegalStateException("The new refresh token scope'"+scopes+"' is not identical to that of the refresh token included by the client in the request: " + this.refreshTokenGrantRequest.getScopes());

--- a/oauth2-client-retrofit2/src/test/java/net/oauth2/client/retrofit/ExtendedTokenServiceIT.java
+++ b/oauth2-client-retrofit2/src/test/java/net/oauth2/client/retrofit/ExtendedTokenServiceIT.java
@@ -1,46 +1,43 @@
-/* 
+/*
  * Copyright (c) 2017 Georgi Pavlov (georgi.pavlov@isoft-technology.com).
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the MIT license which accompanies 
- * this distribution, and is available at 
+ * are made available under the terms of the MIT license which accompanies
+ * this distribution, and is available at
  * https://github.com/tengia/oauth-2/blob/master/LICENSE
  */
 package net.oauth2.client.retrofit;
 
 import java.io.IOException;
 
-import org.junit.Test;
-
 import net.oauth2.AccessToken;
 import net.oauth2.ClientCredentialsGrantRequest;
 import net.oauth2.client.TokenService;
+import okhttp3.Credentials;
 import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ExtendedTokenServiceIT {
-	
-	protected String geolocation;
 
-	@Test
-	public void test() throws IOException {
-		MockWebServer server = new MockWebServer();
+    @Test
+    public void test() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
 
-		// Schedule some responses.
-		server.enqueue(new MockResponse().setBody("{"
-			 + "	\"access_token\": \"1234\","
-			 + "	\"expiresIn\": 3600,"
-			 + "	\"refresh_token\":\"456\","
-			 + "	\"token_type\": \"Bearer\","
-			 + "	\"geolocation\": \"custom\""
-			 + "}"));
-		
-		server.start();
-		
-		HttpUrl baseUrl = server.url("/token");
-		String url = baseUrl.url().toExternalForm().substring(0,  baseUrl.url().toExternalForm().indexOf("token"));
-		TokenService ts = new RetrofitTokenService<TokenEndpoint, AccessToken>(url, new ClientCredentialsGrantRequest("123", "123", null), "", "" , null, null);
-		AccessToken myToken = ts.fetch();
+        // Schedule some responses.
+        setResponseBody(server);
+
+        server.start();
+
+        HttpUrl baseUrl = server.url("/token");
+        String url = baseUrl.url().toExternalForm().substring(0, baseUrl.url().toExternalForm().indexOf("token"));
+        TokenService ts = new RetrofitTokenService<>(url, new ClientCredentialsGrantRequest("123", "123", null), "", "", null, null);
+        ts.fetch();
 		/*String url = baseUrl.url().toExternalForm().substring(0,  baseUrl.url().toExternalForm().indexOf("token"));
 		Retrofit retrofitServiceFactory = new Retrofit.Builder()
 														.baseUrl(url)
@@ -52,9 +49,72 @@ public class ExtendedTokenServiceIT {
 		
 		Response<MyToken> tokenResponse = token.execute();
 		System.out.println(tokenResponse.body().getGeolocation());*/
-		
-		System.out.println(myToken);
-		server.shutdown();
-	}
+
+        RecordedRequest request = server.takeRequest();
+        assertNull(request.getHeader("Authorization"));
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testWithUserIdAndPasswordShouldHaveAuthorizeHeader() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        setResponseBody(server);
+
+        server.start();
+
+        HttpUrl baseUrl = server.url("/token");
+        String url = baseUrl.url().toExternalForm().substring(0, baseUrl.url().toExternalForm().indexOf("token"));
+        TokenService ts = new RetrofitTokenService<>(url, new ClientCredentialsGrantRequest("123", "123", null), "x", "y", null, null);
+        ts.fetch();
+        RecordedRequest request = server.takeRequest();
+        assertEquals("Basic eDp5", request.getHeader("Authorization"));
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testWithUserIdAndPasswordAndExistingAuthorizeHeaderShouldHaveOriginalAuthorizeHeader() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+        setResponseBody(server);
+
+        server.start();
+
+        HttpUrl baseUrl = server.url("/token");
+        String url = baseUrl.url().toExternalForm().substring(0, baseUrl.url().toExternalForm().indexOf("token"));
+
+        OkHttpClient httpClient = getHttpClient();
+        TokenService ts = new RetrofitTokenService<TokenEndpoint, AccessToken>(url,
+                                                                               new ClientCredentialsGrantRequest("123", "123", null),
+                                                                               httpClient,
+                                                                               null, null, null);
+
+        ts.fetch();
+        RecordedRequest request = server.takeRequest();
+        assertNull(request.getHeader("Authorization"));
+        server.shutdown();
+    }
+
+    private void setResponseBody(MockWebServer server) {
+        // Schedule some responses.
+        server.enqueue(new MockResponse().setBody("{"
+                                                  + "	\"access_token\": \"1234\","
+                                                  + "	\"expiresIn\": 3600,"
+                                                  + "	\"refresh_token\":\"456\","
+                                                  + "	\"token_type\": \"Bearer\","
+                                                  + "	\"geolocation\": \"custom\""
+                                                  + "}"));
+
+
+    }
+
+    private OkHttpClient getHttpClient() {
+        return new OkHttpClient.Builder()
+                .addInterceptor(chain -> {
+                    okhttp3.Request request = chain.request();
+                    request.newBuilder().addHeader("Authorization", Credentials.basic("g", "h")).build();
+                    return chain.proceed(request);
+                }).build();
+    }
 
 }

--- a/oauth2-client/pom.xml
+++ b/oauth2-client/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>	
 	

--- a/oauth2-client/src/test/java/net/oauth2/client/AutoRenewingTokenProviderTest.java
+++ b/oauth2-client/src/test/java/net/oauth2/client/AutoRenewingTokenProviderTest.java
@@ -8,6 +8,7 @@
 package net.oauth2.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -15,23 +16,20 @@ import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAmount;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -88,7 +86,7 @@ public class AutoRenewingTokenProviderTest {
 		given(trs.tokenRenewTask.getToken()).willReturn(expectedTemporalToken);		
 		Duration delayDuration = trs.estimatedRepetitionsDelay();
 		assertNotNull(delayDuration);
-		assertTrue(delayDuration.compareTo(Duration.ofSeconds(1L)) == 0);
+		assertEquals(0, delayDuration.compareTo(Duration.ofSeconds(1L)));
 	}
 	
 /*	@Test
@@ -144,7 +142,7 @@ public class AutoRenewingTokenProviderTest {
 	}*/
 	
 	@Test
-	public void testDelayNullWhileNotStarted() throws OAuth2ProtocolException, IOException {
+	public void testDelayNullWhileNotStarted() {
 		AutoRenewingTokenProvider<AccessToken> trs = new AutoRenewingTokenProvider<>(this.tokenService);
 		try{
 			trs.estimatedRepetitionsDelay();
@@ -264,17 +262,17 @@ public class AutoRenewingTokenProviderTest {
 	@Test
 	public void testNoRetryPolicy() {
 		RetryPolicy policy = new NoRetryPolicy();
-		assertTrue(policy.maxRetries() == 1);
-		assertTrue(policy.onException(new IOException()) == false);
-		assertTrue(policy.periodBetweenRetries() == 0);
+		assertEquals(1, policy.maxRetries());
+		assertFalse(policy.onException(new IOException()));
+		assertEquals(0, policy.periodBetweenRetries());
 	}
 
 	@Test
 	public void testMinRetryPolicy() {
 		RetryPolicy policy = new MinimalRetryPolicy();
-		assertTrue(policy.maxRetries() == 3);
-		assertTrue(policy.onException(new IOException()) == true);
-		assertTrue(policy.periodBetweenRetries() == 60000L);
+		assertEquals(3, policy.maxRetries());
+		assertTrue(policy.onException(new IOException()));
+		assertEquals(60000L, policy.periodBetweenRetries());
 	}
 
 /*	@Test
@@ -320,7 +318,7 @@ public class AutoRenewingTokenProviderTest {
 	}*/
 	
 	@Test
-	public void testRefresh() throws IOException, ExecutionException {
+	public void testRefresh() throws IOException {
 		long expireInPeriod = 600L;// Tokens TTL is 600ms
 		final TemporalAccessToken<AccessToken> temporalFetchedToken = TemporalAccessToken.create(new AccessToken("fetched",null,expireInPeriod,"refresh-token",null)).ttlUnit(ChronoUnit.MILLIS);
 		given(this.tokenService.fetch()).willReturn(temporalFetchedToken.token());

--- a/oauth2-commons/pom.xml
+++ b/oauth2-commons/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>	
 	

--- a/oauth2-databinding-gson/pom.xml
+++ b/oauth2-databinding-gson/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>
 

--- a/oauth2-databinding-jackson/pom.xml
+++ b/oauth2-databinding-jackson/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>
 

--- a/oauth2-parent/pom.xml
+++ b/oauth2-parent/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-client-bom</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-client-bom/pom.xml</relativePath>
 	</parent>
 
@@ -41,7 +41,7 @@
 		<url>https://github.com/tengia/oauth-2</url>
 		<connection>scm:git:git@github.com:tengia/oauth-2.git</connection>
 		<developerConnection>scm:git:git@github.com:tengia/oauth-2.git</developerConnection>
-		<tag>v1.1.0</tag>
+		<tag>v1.1.1</tag>
 	</scm>
 
 	<issueManagement>

--- a/oauth2-samples/pom.xml
+++ b/oauth2-samples/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>net.oauth-2</groupId>
 		<artifactId>oauth2-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 		<relativePath>../oauth2-parent/pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
Fixes discovered when integrating with Okta.

Fixes #2
- Handle space separate scope string.
- Do not add an authorization header when a userName and password are not present
- Handle integer expires_in
- Spelling correction for "Frields"
- Misc simplification of test assertions.
- Add .editorconfig to handle indentation as tabs
- misc line ending removal of extra spaces.